### PR TITLE
fix: change docker-build-and-push config

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -111,12 +111,21 @@ jobs:
     needs: build-and-test
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
-      - run: docker build -t ${{ secrets.DOCKER_USERNAME }}/ai-mlops-project:latest .
-      - run: |
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-          docker push ${{ secrets.DOCKER_USERNAME }}/ai-mlops-project:latest
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Docker image
+        run: |
+          docker build -t ghcr.io/${{ github.repository_owner }}/ai-mlops-project:latest .
+
+      - name: Push to GHCR
+        run: docker push ghcr.io/${{ github.repository_owner }}/ai-mlops-project:latest
 
   model-smoke-test:
     needs: build-and-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM python:3.11-slim
 RUN apt-get update && apt-get install -y curl openjdk-17-jdk make build-essential && rm -rf /var/lib/apt/lists/*
 
 # Install Spark
-ENV SPARK_VERSION=3.5.1
+ENV SPARK_VERSION=3.5.6
 ENV HADOOP_VERSION=3
-RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz | tar -xz -C /opt/
+#RUN curl -L https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz | tar -xz -C /opt/
+RUN curl -L --retry 5 --retry-delay 10 https://downloads.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz | tar -xz -C /opt/
 ENV SPARK_HOME=/opt/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}
 ENV PATH="${SPARK_HOME}/bin:${PATH}"
 


### PR DESCRIPTION
## 📦 Pull Request

### 📋 Description
This PR updates the docker-build-and-push job in the CI/CD pipeline to push the Docker image to GitHub Container Registry (GHCR) instead of Docker Hub. It also ensures correct authentication using GITHUB_TOKEN and sets required permissions for package publishing.

### 🧪 What has been tested?
Explain what tests were performed or what part of the pipeline was verified.

### 📂 Files Modified
- [x] `Dockerfile`
- [x] `.github/workflows/ci-cd.yml`

### 📎 Additional Notes
Nothing
